### PR TITLE
First Implementation of `$expand` Query Parameter.

### DIFF
--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/EntityRequestHandlerImpl.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/EntityRequestHandlerImpl.java
@@ -8,7 +8,12 @@ package org.n52.sta.service.handler;
 import java.util.List;
 import java.util.Locale;
 import org.apache.olingo.commons.api.data.Entity;
+import org.apache.olingo.commons.api.data.Link;
+import org.apache.olingo.commons.api.edm.EdmElement;
 import org.apache.olingo.commons.api.edm.EdmEntitySet;
+import org.apache.olingo.commons.api.edm.EdmEntityType;
+import org.apache.olingo.commons.api.edm.EdmNavigationProperty;
+import org.apache.olingo.commons.api.edm.EdmNavigationPropertyBinding;
 import org.apache.olingo.commons.api.http.HttpStatusCode;
 import org.apache.olingo.server.api.ODataApplicationException;
 import org.apache.olingo.server.api.uri.UriInfo;
@@ -57,9 +62,13 @@ public class EntityRequestHandlerImpl implements AbstractEntityRequestHandler {
         } else {
             response = createResponseForNavigation(resourcePaths);
         }
+
         if (queryOptions.hasExpandOption()) {
-            response.getEntity().getNavigationLinks().addAll(
-                    queryOptionsHandler.handleExpandOption(queryOptions.getExpandOption(), response.getEntitySet()));
+            List<Link> links = queryOptionsHandler.handleExpandOption(queryOptions.getExpandOption(),
+                                                                      Long.parseLong(response.getEntity().getProperty("@iot.id").getValue().toString()),
+                                                                      response.getEntitySet(),
+                                                                      queryOptions.getBaseURI());
+            response.getEntity().getNavigationLinks().addAll(links);
         }
         return response;
     }
@@ -77,7 +86,7 @@ public class EntityRequestHandlerImpl implements AbstractEntityRequestHandler {
 
         if (responseEntity == null) {
             throw new ODataApplicationException("Entity not found.",
-                    HttpStatusCode.NOT_FOUND.getStatusCode(), Locale.ROOT);
+                                                HttpStatusCode.NOT_FOUND.getStatusCode(), Locale.ROOT);
         }
 
         // set Entity response information
@@ -110,7 +119,7 @@ public class EntityRequestHandlerImpl implements AbstractEntityRequestHandler {
             }
             if (responseEntity == null) {
                 throw new ODataApplicationException("Entity not found.",
-                        HttpStatusCode.NOT_FOUND.getStatusCode(), Locale.ROOT);
+                                                    HttpStatusCode.NOT_FOUND.getStatusCode(), Locale.ROOT);
             }
         }
 

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityCollectionProcessor.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityCollectionProcessor.java
@@ -28,6 +28,7 @@ import org.apache.olingo.server.api.uri.UriInfo;
 import org.n52.sta.service.handler.AbstractEntityCollectionRequestHandler;
 import org.n52.sta.service.query.QueryOptions;
 import org.n52.sta.service.query.QueryOptionsHandler;
+import org.n52.sta.service.query.URIQueryOptions;
 import org.n52.sta.service.response.EntityCollectionResponse;
 import org.n52.sta.service.serializer.SensorThingsSerializer;
 import org.n52.sta.utils.EntityAnnotator;
@@ -57,7 +58,7 @@ public class SensorThingsEntityCollectionProcessor implements EntityCollectionPr
     @Override
     public void readEntityCollection(ODataRequest request, ODataResponse response, UriInfo uriInfo,
             ContentType contentType) throws ODataApplicationException, ODataLibraryException {
-        QueryOptions queryOptions = new QueryOptions(uriInfo, request.getRawBaseUri());
+        QueryOptions queryOptions = new URIQueryOptions(uriInfo, request.getRawBaseUri());
 
         EntityCollectionResponse entityCollectionResponse = requestHandler.handleEntityCollectionRequest(
                 uriInfo.getUriResourceParts(), queryOptions);

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityCollectionProcessor.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityCollectionProcessor.java
@@ -101,6 +101,7 @@ public class SensorThingsEntityCollectionProcessor implements EntityCollectionPr
                         .id(id)
                         .contextURL(contextUrl)
                         .select(queryOptions.getSelectOption())
+                        .expand(queryOptions.getExpandOption())
                         .count(queryOptions.getCountOption())
                         .build();
         SerializerResult serializerResult = serializer.entityCollection(serviceMetadata, edmEntityType, response.getEntityCollection(), opts);

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityProcessor.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityProcessor.java
@@ -7,6 +7,7 @@ package org.n52.sta.service.processor;
 
 import java.io.InputStream;
 import java.util.Locale;
+
 import org.apache.olingo.commons.api.data.ContextURL;
 import org.apache.olingo.commons.api.edm.EdmEntityType;
 import org.apache.olingo.commons.api.format.ContentType;
@@ -27,6 +28,7 @@ import org.apache.olingo.server.api.uri.UriInfo;
 import org.n52.sta.service.handler.AbstractEntityRequestHandler;
 import org.n52.sta.service.query.QueryOptions;
 import org.n52.sta.service.query.QueryOptionsHandler;
+import org.n52.sta.service.query.URIQueryOptions;
 import org.n52.sta.service.response.EntityResponse;
 import org.n52.sta.service.serializer.SensorThingsSerializer;
 import org.n52.sta.utils.EntityAnnotator;
@@ -55,7 +57,7 @@ public class SensorThingsEntityProcessor implements EntityProcessor {
 
     @Override
     public void readEntity(ODataRequest request, ODataResponse response, UriInfo uriInfo, ContentType responseFormat) throws ODataApplicationException, ODataLibraryException {
-        QueryOptions queryOptions = new QueryOptions(uriInfo, request.getRawBaseUri());
+        QueryOptions queryOptions = new URIQueryOptions(uriInfo, request.getRawBaseUri());
         EntityResponse entityResponse = requestHandler.handleEntityRequest(uriInfo.getUriResourceParts(), queryOptions);
 
         InputStream serializedContent = createResponseContent(serviceMetadata, entityResponse, queryOptions);

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityProcessor.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsEntityProcessor.java
@@ -103,12 +103,13 @@ public class SensorThingsEntityProcessor implements EntityProcessor {
         if (queryOptions.hasSelectOption()) {
             contextUrlBuilder.selectList(queryOptionsHandler.getSelectListFromSelectOption(queryOptions.getSelectOption(), edmEntityType));
         }
-
+        
         ContextURL contextUrl = contextUrlBuilder.build();
 
         EntitySerializerOptions opts = EntitySerializerOptions.with()
                 .contextURL(contextUrl)
                 .select(queryOptions.getSelectOption())
+                .expand(queryOptions.getExpandOption())
                 .build();
 
         SerializerResult serializerResult = serializer.entity(serviceMetadata, response.getEntitySet().getEntityType(), response.getEntity(), opts);

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsReferenceCollectionProcessor.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsReferenceCollectionProcessor.java
@@ -7,6 +7,7 @@ package org.n52.sta.service.processor;
 
 import java.io.InputStream;
 import java.util.List;
+
 import org.apache.olingo.commons.api.data.ContextURL;
 import org.apache.olingo.commons.api.data.Entity;
 import org.apache.olingo.commons.api.edm.EdmEntityType;
@@ -28,6 +29,7 @@ import org.apache.olingo.server.api.uri.UriInfo;
 import org.apache.olingo.server.api.uri.UriResource;
 import org.n52.sta.service.handler.AbstractEntityCollectionRequestHandler;
 import org.n52.sta.service.query.QueryOptions;
+import org.n52.sta.service.query.URIQueryOptions;
 import org.n52.sta.service.response.EntityCollectionResponse;
 import org.n52.sta.service.serializer.SensorThingsSerializer;
 import org.n52.sta.utils.EntityAnnotator;
@@ -53,7 +55,7 @@ public class SensorThingsReferenceCollectionProcessor implements ReferenceCollec
 
     @Override
     public void readReferenceCollection(ODataRequest request, ODataResponse response, UriInfo uriInfo, ContentType responseFormat) throws ODataApplicationException, ODataLibraryException {
-        QueryOptions queryOptions = new QueryOptions(uriInfo, request.getRawBaseUri());
+        QueryOptions queryOptions = new URIQueryOptions(uriInfo, request.getRawBaseUri());
         List<UriResource> resourcePaths = uriInfo.getUriResourceParts();
         EntityCollectionResponse entityCollectionResponse
                 = requestHandler.handleEntityCollectionRequest(resourcePaths.subList(0, resourcePaths.size() - 1),

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsReferenceProcessor.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/processor/SensorThingsReferenceProcessor.java
@@ -7,6 +7,7 @@ package org.n52.sta.service.processor;
 
 import java.io.InputStream;
 import java.util.List;
+
 import org.apache.olingo.commons.api.data.ContextURL;
 import org.apache.olingo.commons.api.format.ContentType;
 import org.apache.olingo.commons.api.http.HttpHeader;
@@ -26,6 +27,7 @@ import org.apache.olingo.server.api.uri.UriInfo;
 import org.apache.olingo.server.api.uri.UriResource;
 import org.n52.sta.service.handler.AbstractEntityRequestHandler;
 import org.n52.sta.service.query.QueryOptions;
+import org.n52.sta.service.query.URIQueryOptions;
 import org.n52.sta.service.response.EntityResponse;
 import org.n52.sta.service.serializer.SensorThingsSerializer;
 import org.n52.sta.utils.EntityAnnotator;
@@ -53,7 +55,7 @@ public class SensorThingsReferenceProcessor implements ReferenceProcessor {
 
     @Override
     public void readReference(ODataRequest request, ODataResponse response, UriInfo uriInfo, ContentType responseFormat) throws ODataApplicationException, ODataLibraryException {
-        QueryOptions options = new QueryOptions(uriInfo, request.getRawBaseUri());
+        QueryOptions options = new URIQueryOptions(uriInfo, request.getRawBaseUri());
         List<UriResource> resourcePaths = uriInfo.getUriResourceParts();
         EntityResponse entityResponse = requestHandler.handleEntityRequest(resourcePaths.subList(0, resourcePaths.size() - 1), options);
 

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/query/ExpandItemQueryOptions.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/query/ExpandItemQueryOptions.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2012-2018 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sta.service.query;
+
+import org.apache.olingo.server.api.uri.UriInfo;
+import org.apache.olingo.server.api.uri.queryoption.CountOption;
+import org.apache.olingo.server.api.uri.queryoption.ExpandItem;
+import org.apache.olingo.server.api.uri.queryoption.ExpandOption;
+import org.apache.olingo.server.api.uri.queryoption.OrderByOption;
+import org.apache.olingo.server.api.uri.queryoption.SelectOption;
+import org.apache.olingo.server.api.uri.queryoption.SkipOption;
+import org.apache.olingo.server.api.uri.queryoption.SystemQueryOption;
+import org.apache.olingo.server.api.uri.queryoption.TopOption;
+import org.apache.olingo.server.core.uri.queryoption.TopOptionImpl;
+import org.n52.sta.data.service.AbstractSensorThingsEntityService;
+
+/**
+ * Class that holds an {@link ExpandItem} to get {@link SystemQueryOption}s to
+ * use them in the {@link AbstractSensorThingsEntityService}s.
+ *
+ * @see org.n52.sta.service.query.QueryOptions 
+ * 
+ * @author <a href="mailto:j.speckamp@52north.org">Jan Speckamp</a>
+ * @since 1.0.0
+ */
+public class ExpandItemQueryOptions implements QueryOptions {
+
+    private ExpandItem item;
+    private String baseURI;
+    
+    public ExpandItemQueryOptions(ExpandItem item, String baseURI) {
+        this.item = item;
+        this.baseURI = baseURI;
+    }
+    
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getUriInfo()
+     */
+    @Override
+    public UriInfo getUriInfo() {
+        return null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getBaseURI()
+     */
+    @Override
+    public String getBaseURI() {
+        return baseURI;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasCountOption()
+     */
+    @Override
+    public boolean hasCountOption() {
+        return item.hasCountPath();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getCountOption()
+     */
+    @Override
+    public CountOption getCountOption() {
+        return item.getCountOption();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getTopOption()
+     */
+    @Override
+    public TopOption getTopOption() {
+        if (item.getTopOption() != null && getUriInfo().getTopOption().getValue() <= DEFAULT_TOP) {
+            return item.getTopOption();
+        }
+        return new TopOptionImpl().setValue(DEFAULT_TOP);
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasSkipOption()
+     */
+    @Override
+    public boolean hasSkipOption() {
+        return item.getSkipOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getSkipOption()
+     */
+    @Override
+    public SkipOption getSkipOption() {
+        return item.getSkipOption();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasOrderByOption()
+     */
+    @Override
+    public boolean hasOrderByOption() {
+        return item.getOrderByOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getOrderByOption()
+     */
+    @Override
+    public OrderByOption getOrderByOption() {
+        return item.getOrderByOption();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasSelectOption()
+     */
+    @Override
+    public boolean hasSelectOption() {
+        return item.getSelectOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getSelectOption()
+     */
+    @Override
+    public SelectOption getSelectOption() {
+        return item.getSelectOption();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasExpandOption()
+     */
+    @Override
+    public boolean hasExpandOption() {
+        return item.getExpandOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getExpandOption()
+     */
+    @Override
+    public ExpandOption getExpandOption() {
+        return item.getExpandOption();
+    }
+
+}

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/query/ExpandItemQueryOptions.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/query/ExpandItemQueryOptions.java
@@ -96,7 +96,7 @@ public class ExpandItemQueryOptions implements QueryOptions {
      */
     @Override
     public TopOption getTopOption() {
-        if (item.getTopOption() != null && getUriInfo().getTopOption().getValue() <= DEFAULT_TOP) {
+        if (item.getTopOption() != null && item.getTopOption().getValue() <= DEFAULT_TOP) {
             return item.getTopOption();
         }
         return new TopOptionImpl().setValue(DEFAULT_TOP);

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/query/QueryOptions.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/query/QueryOptions.java
@@ -1,3 +1,32 @@
+/*
+ * Copyright (C) 2012-2018 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+
 package org.n52.sta.service.query;
 
 import org.apache.olingo.server.api.uri.UriInfo;
@@ -6,164 +35,109 @@ import org.apache.olingo.server.api.uri.queryoption.ExpandOption;
 import org.apache.olingo.server.api.uri.queryoption.OrderByOption;
 import org.apache.olingo.server.api.uri.queryoption.SelectOption;
 import org.apache.olingo.server.api.uri.queryoption.SkipOption;
-import org.apache.olingo.server.api.uri.queryoption.SystemQueryOption;
 import org.apache.olingo.server.api.uri.queryoption.TopOption;
-import org.apache.olingo.server.core.uri.queryoption.TopOptionImpl;
 import org.n52.sta.data.service.AbstractSensorThingsEntityService;
 
 /**
- * Class that holds the {@link UriInfo} to get the {@link SystemQueryOption}s to
- * use them in the {@link AbstractSensorThingsEntityService}s.
- *
+ * Abstract Interface to hold Query Parameters for {@link AbstractSensorThingsEntityService}
+ * 
  * @author Carsten Hollmann <c.hollmann@52north.org>
- * @since 1.0.0
+ * @author <a href="mailto:j.speckamp@52north.org">Jan Speckamp</a>
  *
  */
-public class QueryOptions {
+public interface QueryOptions {
 
-    private static final int DEFAULT_TOP = 100;
-
-    private final UriInfo uriInfo;
-
-    private final String baseURI;
-
-    /**
-     * Constructor
-     *
-     * @param uriInfo the {@link UriInfo} of the query
-     * @param baseURI the baseURI
-     */
-    public QueryOptions(UriInfo uriInfo, String baseURI) {
-        this.uriInfo = uriInfo;
-        this.baseURI = baseURI;
-    }
-
+    static final int DEFAULT_TOP = 100;
+    
     /**
      * Get the {@link UriInfo}
      *
      * @return the uriInfo
      */
-    public UriInfo getUriInfo() {
-        return uriInfo;
-    }
+    public UriInfo getUriInfo();
 
     /**
      * Get the baseURI
      *
      * @return the baseURI
      */
-    public String getBaseURI() {
-        return baseURI;
-    }
-
+    public String getBaseURI();
+    
     /**
-     * Check if the {@link UriInfo} holds {@link CountOption}
+     * Check if {@link CountOption} is present
      *
-     * @return <code>true</code>, if the {@link UriInfo} holds
-     * {@link CountOption}
+     * @return <code>true</code>, if {@link CountOption} is present
      */
-    public boolean hasCountOption() {
-        return getUriInfo().getCountOption() != null && getUriInfo().getCountOption().getValue();
-    }
+    boolean hasCountOption();
 
     /**
-     * Get the {@link CountOption} from {@link UriInfo}
+     * Get the {@link CountOption}
      *
      * @return the {@link CountOption}
      */
-    public CountOption getCountOption() {
-        return getUriInfo().getCountOption();
-    }
-
-    private boolean hasTopOption() {
-        return getUriInfo().getTopOption() != null;
-    }
-
+    CountOption getCountOption();
+    
     /**
-     * Get the {@link TopOption} from {@link UriInfo} or the default with 100
+     * Get the {@link TopOption}. If {@link TopOption} is missing return {@link QueryOptions.DEFAULT_TOP}
      *
      * @return the {@link TopOption}
      */
-    public TopOption getTopOption() {
-        if (hasTopOption() && getUriInfo().getTopOption().getValue() <= DEFAULT_TOP) {
-            return getUriInfo().getTopOption();
-        }
-        return new TopOptionImpl().setValue(DEFAULT_TOP);
-    }
+    TopOption getTopOption();
 
     /**
-     * Check if the {@link UriInfo} holds {@link SkipOption}
+     * Check if {@link SkipOption} is present
      *
-     * @return <code>true</code>, if the {@link UriInfo} holds
-     * {@link SkipOption}
+     * @return <code>true</code>, if {@link SkipOption} is present
      */
-    public boolean hasSkipOption() {
-        return getUriInfo().getSkipOption() != null;
-    }
+    boolean hasSkipOption();
 
     /**
-     * Get the {@link SkipOption} from {@link UriInfo}
+     * Get the {@link SkipOption}
      *
      * @return the {@link SkipOption}
      */
-    public SkipOption getSkipOption() {
-        return getUriInfo().getSkipOption();
-    }
+    SkipOption getSkipOption();
 
     /**
-     * Check if the {@link UriInfo} holds {@link OrderByOption}
+     * Check if {@link OrderByOption} is present
      *
-     * @return <code>true</code>, if the {@link UriInfo} holds
-     * {@link OrderByOption}
+     * @return <code>true</code>, if {@link OrderByOption} is present
      */
-    public boolean hasOrderByOption() {
-        return getUriInfo().getOrderByOption() != null;
-    }
+    boolean hasOrderByOption();
 
     /**
-     * Get the {@link OrderByOption} from {@link UriInfo}
+     * Get the {@link OrderByOption}
      *
      * @return the {@link OrderByOption}
      */
-    public OrderByOption getOrderByOption() {
-        return getUriInfo().getOrderByOption();
-    }
+    OrderByOption getOrderByOption();
 
     /**
-     * * Check if the {@link UriInfo} holds {@link SelectOption}
+     * * Check if {@link SelectOption} is present
      *
-     * @return <code>true</code>, if the {@link UriInfo} holds
-     * {@link SelectOption}
+     * @return <code>true</code>, if the {@link SelectOption} is present
      */
-    public boolean hasSelectOption() {
-        return getUriInfo().getSelectOption() != null;
-    }
+    boolean hasSelectOption();
 
     /**
-     * Get the {@link SelectOption} from {@link UriInfo}
+     * Get the {@link SelectOption}
      *
      * @return the {@link SelectOption}
      */
-    public SelectOption getSelectOption() {
-        return getUriInfo().getSelectOption();
-    }
+    SelectOption getSelectOption();
 
     /**
-     * * Check if the {@link UriInfo} holds {@link ExpandOption}
+     * * Check if {@link ExpandOption} is present
      *
-     * @return <code>true</code>, if the {@link UriInfo} holds
-     * {@link ExpandOption}
+     * @return <code>true</code>, if {@link ExpandOption} is present
      */
-    public boolean hasExpandOption() {
-        return getUriInfo().getExpandOption() != null;
-    }
+    boolean hasExpandOption();
 
     /**
-     * Get the {@link ExpandOption} from {@link UriInfo}
+     * Get the {@link ExpandOption}
      *
      * @return the {@link ExpandOption}
      */
-    public ExpandOption getExpandOption() {
-        return getUriInfo().getExpandOption();
-    }
+    ExpandOption getExpandOption();
+
 }

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/query/QueryOptions.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/query/QueryOptions.java
@@ -28,7 +28,7 @@ public class QueryOptions {
     private final String baseURI;
 
     /**
-     * Constuctor
+     * Constructor
      *
      * @param uriInfo the {@link UriInfo} of the query
      * @param baseURI the baseURI

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/query/QueryOptionsHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/query/QueryOptionsHandler.java
@@ -86,7 +86,7 @@ public class QueryOptionsHandler {
             EdmEntityType targetEdmEntityType = null;
             String targetTitle = null;
                 
-            // TODO: Expand to nested paths
+            // TODO: Expand to support nested paths
             UriResource uriResource = expandItem.getResourcePath().getUriResourceParts().get(0);
     
             if(uriResource instanceof UriResourceNavigation) {
@@ -110,7 +110,6 @@ public class QueryOptionsHandler {
                                                                     targetEdmEntityType,
                                                                     new ExpandItemQueryOptions(expandItem, baseURI)));
                 
-                //TODO: check for Null Pointer on entity
                 // Annotate inline Entites with appropiate links
                 final EdmEntityType type = targetEdmEntityType;
                 entity.getInlineEntitySet().forEach( inlineEntity -> {entityAnnotator.annotateEntity(inlineEntity, type, baseURI);});
@@ -119,12 +118,13 @@ public class QueryOptionsHandler {
                                                        sourceEdmEntitySet,
                                                        targetEdmEntityType));
                 
-                //TODO: check for Null Pointer on entity
                 // Annotate inline Entites with appropiate links
                 entityAnnotator.annotateEntity(entity.getInlineEntity(), targetEdmEntityType, baseURI);    
             }
-            
-            links.add(entity);
+            // Only add valid Elements
+            if (entity != null) {
+                links.add(entity);
+            }
         });
         
         return links;

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/query/URIQueryOptions.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/query/URIQueryOptions.java
@@ -1,0 +1,152 @@
+package org.n52.sta.service.query;
+
+import org.apache.olingo.server.api.uri.UriInfo;
+import org.apache.olingo.server.api.uri.queryoption.CountOption;
+import org.apache.olingo.server.api.uri.queryoption.ExpandOption;
+import org.apache.olingo.server.api.uri.queryoption.OrderByOption;
+import org.apache.olingo.server.api.uri.queryoption.SelectOption;
+import org.apache.olingo.server.api.uri.queryoption.SkipOption;
+import org.apache.olingo.server.api.uri.queryoption.SystemQueryOption;
+import org.apache.olingo.server.api.uri.queryoption.TopOption;
+import org.apache.olingo.server.core.uri.queryoption.TopOptionImpl;
+import org.n52.sta.data.service.AbstractSensorThingsEntityService;
+
+/**
+ * Class that holds the {@link UriInfo} to get the {@link SystemQueryOption}s to
+ * use them in the {@link AbstractSensorThingsEntityService}s.
+ *
+ * @author Carsten Hollmann <c.hollmann@52north.org>
+ * @since 1.0.0
+ *
+ */
+public class URIQueryOptions implements QueryOptions {
+
+    private final UriInfo uriInfo;
+
+    private final String baseURI;
+
+    /**
+     * Constructor
+     *
+     * @param uriInfo the {@link UriInfo} of the query
+     * @param baseURI the baseURI
+     */
+    public URIQueryOptions(UriInfo uriInfo, String baseURI) {
+        this.uriInfo = uriInfo;
+        this.baseURI = baseURI;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getUriInfo()
+     */
+    @Override
+    public UriInfo getUriInfo() {
+        return uriInfo;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getBaseURI()
+     */
+    @Override
+    public String getBaseURI() {
+        return baseURI;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasCountOption()
+     */
+    @Override
+    public boolean hasCountOption() {
+        return getUriInfo().getCountOption() != null && getUriInfo().getCountOption().getValue();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getCountOption()
+     */
+    @Override
+    public CountOption getCountOption() {
+        return getUriInfo().getCountOption();
+    }
+    
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getTopOption()
+     */
+    private boolean hasTopOption() {
+        return getUriInfo().getTopOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getTopOption()
+     */
+    @Override
+    public TopOption getTopOption() {
+        if (hasTopOption() && getUriInfo().getTopOption().getValue() <= DEFAULT_TOP) {
+            return getUriInfo().getTopOption();
+        }
+        return new TopOptionImpl().setValue(DEFAULT_TOP);
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasSkipOption()
+     */
+    @Override
+    public boolean hasSkipOption() {
+        return getUriInfo().getSkipOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getSkipOption()
+     */
+    @Override
+    public SkipOption getSkipOption() {
+        return getUriInfo().getSkipOption();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasOrderByOption()
+     */
+    @Override
+    public boolean hasOrderByOption() {
+        return getUriInfo().getOrderByOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getOrderByOption()
+     */
+    @Override
+    public OrderByOption getOrderByOption() {
+        return getUriInfo().getOrderByOption();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasSelectOption()
+     */
+    @Override
+    public boolean hasSelectOption() {
+        return getUriInfo().getSelectOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getSelectOption()
+     */
+    @Override
+    public SelectOption getSelectOption() {
+        return getUriInfo().getSelectOption();
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#hasExpandOption()
+     */
+    @Override
+    public boolean hasExpandOption() {
+        return getUriInfo().getExpandOption() != null;
+    }
+
+    /* (non-Javadoc)
+     * @see org.n52.sta.service.query.QueryOptions#getExpandOption()
+     */
+    @Override
+    public ExpandOption getExpandOption() {
+        return getUriInfo().getExpandOption();
+    }
+}

--- a/sensor-things-api-core/src/main/java/org/n52/sta/utils/EntityAnnotator.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/utils/EntityAnnotator.java
@@ -31,6 +31,11 @@ public class EntityAnnotator {
      * @return the annotated Entity
      */
     public Entity annotateEntity(Entity entity, EdmEntityType entityType, String baseUri) {
+        // Do not annotate if there is nothing to annotate
+        if (entity == null) {
+            return null;
+        }
+        
         String selfLink = String.join("/", baseUri, entity.getId().getPath());
         entity.addProperty(new Property(null, SELF_LINK_ANNOTATION, ValueType.PRIMITIVE, selfLink));
 


### PR DESCRIPTION
First Implementation of `$expand` Query Parameter.

Supports:
 * Inlining of direct Properties (single Elements) e.g. `$expand=Sensor`
 * Inlining of direct Properties (Collections) e.g. `$expand=Datastreams`
   * Individual Query Parameters for each inlined collection (e.g. `$expand=Datastreams($select=name),Locations($top=2)`)

Does **NOT** support: 
 * Expanding of nested Properties (e.g. `$expand=Things/Locations`)