### PR TITLE
bugfixed deletion of entities other than Thing.

### DIFF
--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/DatastreamEntityCrudRequestHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/DatastreamEntityCrudRequestHandler.java
@@ -66,7 +66,7 @@ public class DatastreamEntityCrudRequestHandler extends AbstractEntityCrudReques
 
     @Override
     protected void handleDeleteEntityRequest(String id) throws ODataApplicationException {
-        getEntityService().delete(id);
+        getEntityService().delete(id.replace("\'", ""));
     }
 
     @Override

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/FeatureOfInterestEntityCrudRequestHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/FeatureOfInterestEntityCrudRequestHandler.java
@@ -65,7 +65,7 @@ public class FeatureOfInterestEntityCrudRequestHandler extends AbstractEntityCru
 
     @Override
     protected void handleDeleteEntityRequest(String id) throws ODataApplicationException {
-        getEntityService().delete(id);
+        getEntityService().delete(id.replace("\'", ""));
     }
 
     @Override

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/HistoricalLocationEntityCrudRequestHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/HistoricalLocationEntityCrudRequestHandler.java
@@ -65,7 +65,7 @@ public class HistoricalLocationEntityCrudRequestHandler extends AbstractEntityCr
 
     @Override
     protected void handleDeleteEntityRequest(String id) throws ODataApplicationException {
-        getEntityService().delete(id);
+        getEntityService().delete(id.replace("\'", ""));
     }
 
     @Override

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/LocationEntityCrudRequestHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/LocationEntityCrudRequestHandler.java
@@ -65,7 +65,7 @@ public class LocationEntityCrudRequestHandler extends AbstractEntityCrudRequestH
 
     @Override
     protected void handleDeleteEntityRequest(String id) throws ODataApplicationException {
-           getEntityService().delete(id);
+        getEntityService().delete(id.replace("\'", ""));
     }
 
     @Override

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/ObservationEntityCrudRequestHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/ObservationEntityCrudRequestHandler.java
@@ -68,7 +68,7 @@ public class ObservationEntityCrudRequestHandler extends AbstractEntityCrudReque
 
     @Override
     protected void handleDeleteEntityRequest(String id) throws ODataApplicationException {
-            getEntityService().delete(id);
+        getEntityService().delete(id.replace("\'", ""));
     }
 
     @Override

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/ObservedPropertyEntityCrudRequestHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/ObservedPropertyEntityCrudRequestHandler.java
@@ -66,7 +66,7 @@ public class ObservedPropertyEntityCrudRequestHandler extends AbstractEntityCrud
 
     @Override
     protected void handleDeleteEntityRequest(String id) throws ODataApplicationException {
-            getEntityService().delete(id);
+        getEntityService().delete(id.replace("\'", ""));
     }
 
     @Override

--- a/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/SensorEntityCrudRequestHandler.java
+++ b/sensor-things-api-core/src/main/java/org/n52/sta/service/handler/crud/SensorEntityCrudRequestHandler.java
@@ -66,7 +66,7 @@ public class SensorEntityCrudRequestHandler extends AbstractEntityCrudRequestHan
 
     @Override
     protected void handleDeleteEntityRequest(String id) throws ODataApplicationException {
-            getEntityService().delete(id);
+        getEntityService().delete(id.replace("\'", ""));
     }
 
     @Override


### PR DESCRIPTION
bugfixed delete not working caused by missing removal of escape characters.
Removal was already implemented for ThingCrudRequestHandler but missing in all others.